### PR TITLE
NB1: Remove ndk_platform backend. Use the ndk backend.

### DIFF
--- a/power-libperfmgr/Android.bp
+++ b/power-libperfmgr/Android.bp
@@ -36,7 +36,7 @@ cc_binary {
     vintf_fragments: ["aidl/android.hardware.power-service.nokia_msm8998.xml"],
     vendor: true,
     shared_libs: [
-        "android.hardware.power-V2-ndk_platform",
+        "android.hardware.power-V2-ndk",
         "libbase",
         "libcutils",
         "liblog",
@@ -45,7 +45,7 @@ cc_binary {
         "libdisppower-msm8998",
         "libperfmgr",
         "libprocessgroup",
-        "pixel-power-ext-V1-ndk_platform",
+        "pixel-power-ext-V1-ndk",
     ],
     srcs: [
         "aidl/service.cpp",


### PR DESCRIPTION
The ndk_platform backend will soon be deprecated because the ndk backend
can serve the same purpose. This is to eliminate the confusion about
having two variants (ndk and ndk_platform) for the same ndk backend.

This is also needed to build Android 13 ROMs.